### PR TITLE
run.sh: relax regexp to have it work in Docker

### DIFF
--- a/atl-mr/dist.xml
+++ b/atl-mr/dist.xml
@@ -172,7 +172,7 @@ URIRECORDS=/user/$USER/$RECORDS
 hdfs dfs -mkdir -p /user/$USER/`dirname $RECORDS`
 hdfs dfs -copyFromLocal -f $RECORDS $URIRECORDS
 
-MAPPERS=`yarn node -list | grep -c -E '^\s+\w+:[0-9]+\s+RUNNING\s+'`
+MAPPERS=`yarn node -list | grep -c -E '^\s*\w+:[0-9]+\s*RUNNING\s*'`
 
 yarn jar atl-mr.jar -libjars "$LIBJARS" -files "$SOURCEMM#$SOURCEMM,$TARGETMM#$TARGETMM,$TRANSFORMATION#$TRANSFORMATION,$INPUT#$INPUT" $YARNARGS -r $URIRECORDS -m $MAPPERS
 		</echo>


### PR DESCRIPTION
The version of `yarn` in this popular Hadoop Dockere image does not
produce whitespace at the beginning of the lines with RUNNING. The
original regexp used to compute `MAPPERS` requires this whitespace,
incorrectly asking for 0 mappers and producing an
IntegerFormatException.

This commit relaxes \s+ to \s\* in the regexp so it works again.
